### PR TITLE
DAOS-2822 build: Support TARGET_PREFIX build for using custom psm2

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -101,9 +101,8 @@ def define_mercury(reqs):
                           '--enable-psm2' +
                           check(reqs, 'psm2',
                                 "=$PSM2_PREFIX "
-                                'LDFLAGS="-L$PSM2_PREFIX/lib '
-                                '-Wl,-rpath=$PSM2_PREFIX/lib '
-                                '-Wl,--enable-new-dtags" ', ''),
+                                'LDFLAGS="-Wl,--enable-new-dtags '
+                                '-Wl,-rpath=$PSM2_PREFIX/lib" ', ''),
                           'make $JOBS_OPT',
                           'make install'],
                 libs=['fabric'],

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -99,7 +99,11 @@ def define_mercury(reqs):
                 commands=['./autogen.sh',
                           './configure --prefix=$OFI_PREFIX ' +
                           '--enable-psm2' +
-                          check(reqs, 'psm2', "=$PSM2_PREFIX", ''),
+                          check(reqs, 'psm2',
+                                "=$PSM2_PREFIX "
+                                'LDFLAGS="-L$PSM2_PREFIX/lib '
+                                '-Wl,-rpath=$PSM2_PREFIX/lib '
+                                '-Wl,--enable-new-dtags" ', ''),
                           'make $JOBS_OPT',
                           'make install'],
                 libs=['fabric'],
@@ -374,6 +378,6 @@ def define_components(reqs):
                           'Makefile compat/Makefile',
                           'make $JOBS_OPT',
                           'make DESTDIR=$PSM2_PREFIX install'],
-                libs=['libpsm2'])
+                libs=['psm2'])
 
 __all__ = ['define_components']


### PR DESCRIPTION
If we are using psm2 built from source, add necessary LDFLAGS
to enable DT_RUNPATH to be set in libfabric.so such that downstream
components can link libfabric.so without explicity linking of
libpsm2.so.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>