### PR TITLE
DAOS-623 build: Add check for existence of source directory

### DIFF
--- a/prereq_tools/base.py
+++ b/prereq_tools/base.py
@@ -798,7 +798,9 @@ class PreReqComponent():
 
         for comp in comps:
             try:
-                self.get_src_path(comp)
+                path = self.get_src_path(comp)
+                if not os.path.exists(path):
+                    return False
             except MissingPath as _error:
                 print("%s source not found" % comp)
                 return False


### PR DESCRIPTION
If source is in default location, we need to actually check
its existence or the function will return True.  This caused
failure with RPM builds in CI

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>